### PR TITLE
Update kopt and findpole

### DIFF
--- a/pyprima/src/pyprima/cobyla/update.py
+++ b/pyprima/src/pyprima/cobyla/update.py
@@ -124,14 +124,14 @@ def findpole(cpen, cval, fval):
     # Identify the optimal vertex of the current simplex
     jopt = np.size(fval) - 1
     phi = fval + cpen * cval
-    phimin = np.min(phi)
-    joptcandidate = np.argmin(phi)
-    if phi[joptcandidate] < phi[jopt]:
-        jopt = joptcandidate
-    if cpen <= 0 and any(cval < cval[jopt] & phi <= phimin):
-        # jopt is the index of the minimum value of cval
-        # on the set of cval values where phi <= phimin
-        jopt = np.where(cval == np.min(cval[phi <= phimin]))[0][0]
+    phimin = min(phi)
+    # Essentially jopt = np.argmin(phi). However, we keep jopt = num_vars unless there
+    # is a strictly better choice. When there are multiple choices, we choose the jopt
+    # with the smallest value of cval.
+    if phimin < phi[jopt] or any((cval < cval[jopt]) & (phi <= phi[jopt])):
+        # While we could use argmin(phi), there may be two places where phi achieves
+        # phimin, and in that case we should choose the one with the smallest cval.
+        jopt = np.ma.array(cval, mask=(phi > phimin)).argmin()
 
     #==================#
     # Calculation ends #

--- a/pyprima/src/pyprima/common/powalg.py
+++ b/pyprima/src/pyprima/common/powalg.py
@@ -117,6 +117,5 @@ def qrexc_Rdiag(A, Q, Rdiag, i):  # Used in COBYLA
     # Calculate Rdiag(i:n) from scratch
     Rdiag[i:n-1] = [np.dot(Q[:, k], A[:, k+1]) for k in range(i, n-1)]
     Rdiag[n-1] = np.dot(Q[:, n-1], A[:, i])
-    # Rdiag = np.array(Rdiag)
 
     return Q, Rdiag

--- a/pyprima/src/pyprima/common/selectx.py
+++ b/pyprima/src/pyprima/common/selectx.py
@@ -153,7 +153,7 @@ def savefilt(cstrv, ctol, cweight, f, x, nfilt, cfilt, ffilt, xfilt, constr=None
         phimax = max(phi)
         cref = max(cfilt_shifted[phi >= phimax])
         fref = max(ffilt[cfilt_shifted >= cref])
-        kworst = np.where(cfilt == max(cfilt[ffilt <= fref]))[0][0]
+        kworst = np.ma.array(cfilt, mask=(ffilt > fref)).argmax()
         if kworst < 0 or kworst >= len(keep):  #  For security. Should not happen.
             kworst = 0
         keep[kworst] = False
@@ -279,7 +279,8 @@ def selectx(fhist: npt.NDArray, chist: npt.NDArray, cweight: float, ctol: float)
         phimin = np.min(phi[np.logical_and(fhist < fref, chist_shifted <= cref)])
         cref = np.min(chist_shifted[np.logical_and(fhist < fref, phi <= phimin)])
         fref = np.min(fhist[chist_shifted <= cref])
-        kopt = np.argmin(chist[fhist <= fref])
+        # Can't use argmin here because using it with a mask throws off the index
+        kopt = np.ma.array(chist, mask=(fhist > fref)).argmin()
 
     #==================#
     # Calculation ends #


### PR DESCRIPTION
Some testing revealed a bug with selection of kopt. Using the mask caused the indices to be mixed up, so we need to use numpy masking facilities.

Earlier I had tried using np.where, but this also created a bug. Fortran's minloc will not consider any indices covered by the mask, whereas the "where array == min(array[mask])" construct will allow indices covered by the mask. So other instances of np.where were fixed.

In investigating the bug it was discovered that findpole differed from the current latest Fortran implementation, likely because it was initially incorrectly implemented from the update.f90 in the benchmark folder.

Redone profiles are attached. They show slight improvement over the profiles in the PR to merge the Python implementation.
[cobyla_different_options.pdf](https://github.com/user-attachments/files/18368166/cobyla_different_options.pdf)
[cobyla_nondefault_options.pdf](https://github.com/user-attachments/files/18368167/cobyla_nondefault_options.pdf)
[cobyla_default_options.pdf](https://github.com/user-attachments/files/18368168/cobyla_default_options.pdf)
