### PR TITLE
Change variable name and docs

### DIFF
--- a/pyprima/tests/conftest.py
+++ b/pyprima/tests/conftest.py
@@ -6,7 +6,7 @@ import sys
 def minimize_with_debugging():
     # This is a hack to force us to use DEBUGGING for a test, so that we get
     # code coverage. We definitely don't want to do this for the pycutest tests,
-    # they are slow enough with COMPARING set to True.
+    # they are slow enough with USE_NAIVE_MATH set to True.
     os.environ['PRIMA_DEBUGGING'] = "True"
     if 'pyprima' in sys.modules:
         modules_to_delete = [m for m in sys.modules if 'pyprima' in m]

--- a/pyprima/tests/test_pycutest.py
+++ b/pyprima/tests/test_pycutest.py
@@ -3,9 +3,9 @@ import pytest
 optiprofiler = pytest.importorskip("optiprofiler", exc_type=ImportError)
 
 from optiprofiler.problems import load_cutest_problem
+import pyprima
 from pyprima import minimize, Bounds, LinearConstraint, NonlinearConstraint
 import numpy as np
-import sys
 
 
 '''
@@ -21,9 +21,9 @@ def set_comparing():
     # This is a hack to force these tests to use manual math instead of optimized
     # numpy or other routines. This should ensure we have the same results across
     # different architectures.
-    sys.modules['pyprima'].common.linalg.COMPARING = True
+    pyprima.common.linalg.USE_NAIVE_MATH = True
     yield
-    sys.modules['pyprima'].common.linalg.COMPARING = False
+    pyprima.common.linalg.USE_NAIVE_MATH = False
 
 
 def get_constraints(problem):


### PR DESCRIPTION
I think we actually want to keep USE_NAIVE_MATH, because sometimes it is useful for problems which appear to be sensitive to finite precision arithmetic.